### PR TITLE
fix: openapi signature

### DIFF
--- a/php/src/OpenApiUtilClient.php
+++ b/php/src/OpenApiUtilClient.php
@@ -295,7 +295,7 @@ class OpenApiUtilClient
      */
     public static function getAuthorization($request, $signatureAlgorithm, $payload, $accesskey, $accessKeySecret)
     {
-        $canonicalURI = $request->pathname;
+        $canonicalURI = $request->pathname ? $request->pathname : '/';
 
         $method               = strtoupper($request->method);
         $canonicalQueryString = self::getCanonicalQueryString($request->query);
@@ -326,8 +326,9 @@ class OpenApiUtilClient
         $canonicalRequest = $method . "\n" . $canonicalURI . "\n" . $canonicalQueryString . "\n" .
             $canonicalHeaderString . "\n" . implode(';', array_keys($signHeaders)) . "\n" . $payload;
         $strtosign        = $signatureAlgorithm . "\n" . self::hexEncode(self::hash(Utils::toBytes($canonicalRequest), $signatureAlgorithm));
-        $signature = self::sign($accessKeySecret, $strtosign, $signatureAlgorithm);
-        $signature = self::hexEncode($signature);
+        $signature        = self::sign($accessKeySecret, $strtosign, $signatureAlgorithm);
+        $signature        = self::hexEncode($signature);
+
         return $signatureAlgorithm .
             ' Credential=' . $accesskey .
             ',SignedHeaders=' . implode(';', array_keys($signHeaders)) .
@@ -447,9 +448,9 @@ class OpenApiUtilClient
         $tmp = [];
         foreach ($query as $k => $v) {
             if (!empty($v)) {
-                $tmp[] = $k . '=' . rawurlencode($v);
+                $tmp[] = $k . '=' . $v;
             } else {
-                $tmp[] = $k . '=';
+                $tmp[] = $k;
             }
         }
 
@@ -520,6 +521,8 @@ class OpenApiUtilClient
             $str = rawurlencode($k);
             if ('' !== $v && null !== $v) {
                 $str .= '=' . rawurlencode($v);
+            } else {
+                $str .= '=';
             }
             $params[] = $str;
         }

--- a/php/tests/OpenApiUtilClientTest.php
+++ b/php/tests/OpenApiUtilClientTest.php
@@ -53,7 +53,7 @@ class OpenApiUtilClientTest extends TestCase
         $request->query = [
             'key' => 'val ue with space',
         ];
-        $this->assertEquals("GET\napplication/json\nmd5\napplication/json\ndate\nx-acs-custom-key:any value\n/?key=val%20ue%20with%20space", OpenApiUtilClient::getStringToSign($request));
+        $this->assertEquals("GET\napplication/json\nmd5\napplication/json\ndate\nx-acs-custom-key:any value\n/?key=val ue with space", OpenApiUtilClient::getStringToSign($request));
     }
 
     public function testGetROASignature()
@@ -262,7 +262,7 @@ class OpenApiUtilClientTest extends TestCase
 
         $res = OpenApiUtilClient::getAuthorization($request, 'ACS3-HMAC-SHA256', '55e12e91650d2fec56ec74e1d3e4ddbfce2ef3a65890c2a19ecf88a307e76a23', 'acesskey', 'secret');
 
-        $this->assertEquals('ACS3-HMAC-SHA256 Credential=acesskey,SignedHeaders=x-acs-test,Signature=6886c2524bed4eb951f857100358da5787d230bc29c7656de91967df8636751b', $res);
+        $this->assertEquals('ACS3-HMAC-SHA256 Credential=acesskey,SignedHeaders=x-acs-test,Signature=b1c354956701e439df07488f1ec270919fe9029f438a9db3970053406a6d1d7e', $res);
     }
 
     public function testSign()


### PR DESCRIPTION
1. Use '/' pathname as default in canonicalURI.
2. Cancel rawurlencode operation when join canonicalQueryString.